### PR TITLE
Disable initial mock validation for zksync era

### DIFF
--- a/packages/oracle/config.json
+++ b/packages/oracle/config.json
@@ -81,8 +81,8 @@
     ]
   },
   "workerManager": {
-    "sequentialFailsThresholdMs": 120000,
-    "restartDelayMs": 20000
+    "sequentialFailsThresholdMs": 180000,
+    "restartDelayMs": 30000
   },
   "oracleWorkers": [
     {
@@ -165,6 +165,7 @@
     {
       "id": "zksync-era-testnet",
       "tickMs": 1000,
+      "disableMockValidation": true,
       "ethereum": {
         "nodeUrl": "https://testnet.era.zksync.dev"
       },

--- a/packages/oracle/src/config/index.ts
+++ b/packages/oracle/src/config/index.ts
@@ -45,6 +45,7 @@ interface UpdatePriceJobConfig {
 export interface OracleWorkerConfig {
   id: string;
   tickMs: number,
+  disableMockValidation: boolean | undefined;
   ethereum: OracleWorkerEthereumConfig,
   tokens: TokenConfig[],
   uniswapV3PoolMocks: UniswapV3PoolMockConfig[];
@@ -84,6 +85,7 @@ interface StrictOracleWorkerEthereumConfig {
 export interface StrictOracleWorkerConfig {
   id: string;
   tickMs: number,
+  disableMockValidation: boolean;
   ethereum: StrictOracleWorkerEthereumConfig,
   tokens: StrictTokenConfig[],
   uniswapV3PoolMocks: UniswapV3PoolMockConfig[];
@@ -161,6 +163,7 @@ function parseOracleWorkerConfig(
   return {
     id: config.id,
     tickMs: config.tickMs,
+    disableMockValidation: config.disableMockValidation ?? false,
     ethereum: {
       nodeUrl: config.ethereum.nodeUrl,
       oraclePrivateKey: config.ethereum.oraclePrivateKey ?? ethereumConfig.oraclePrivateKey,

--- a/packages/oracle/src/worker/worker.ts
+++ b/packages/oracle/src/worker/worker.ts
@@ -245,10 +245,17 @@ export class OracleWorker implements Worker {
       const uniswapV3PoolMockContractDescription = readUniswapMockContract('UniswapV3PoolMock');
 
       const poolMocks = new Map<string, PoolMock>();
-      if (this.transientState.length > 0) {
-        logger.info(`Assuming following mocks are already validated: ${this.transientState.join(', ')}`);
+
+      let alreadyValidatedPoolIds: Set<string>;
+      if (workerConfig.disableMockValidation) {
+        logger.info(`Mock validation is disabled so ignoring transient state if any`);
+        alreadyValidatedPoolIds = new Set(workerConfig.uniswapV3PoolMocks.map(x => x.id));
+      } else {
+        if (this.transientState.length > 0) {
+          logger.info(`Assuming following mocks are already validated: ${this.transientState.join(', ')}`);
+        }
+        alreadyValidatedPoolIds = new Set(this.transientState);
       }
-      const alreadyValidatedPoolIds = new Set(this.transientState);
 
       for (const poolMockConfig of workerConfig.uniswapV3PoolMocks) {
         const contract = new ethers.Contract(poolMockConfig.address, uniswapV3PoolMockContractDescription.abi, oracleSigner);


### PR DESCRIPTION
It's node responses is pretty unstable.
Random errors causes Oracle to restart.
So here we virtually ignore pretty much all errors from ZkSync Era node.