### PR TITLE
fix: state files sort by name desc order

### DIFF
--- a/packages/cli/src/command/deploy/index.ts
+++ b/packages/cli/src/command/deploy/index.ts
@@ -272,7 +272,7 @@ function getLatestStateFileName(dirName: string): string {
       mtimeNs: fs.statSync(path.join(dirName, x), { bigint: true }).mtimeNs,
     }))
     .filter((x) => x.extension === '.json')
-    .sort((a, b) => Number(b.mtimeNs - a.mtimeNs));
+    .sort((a, b) => (a.name > b.name ? -1 : 1));
 
   if (files.length === 0) {
     throw new Error('No state file found');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changes**
  - Improved the logic for identifying the latest state file during deployment by sorting files based on their names instead of modification times. This ensures more predictable and accurate file selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->